### PR TITLE
Modified PandasColumnSelector into PandasColumnsFiltering.

### DIFF
--- a/simple_repo/exception.py
+++ b/simple_repo/exception.py
@@ -23,3 +23,8 @@ class CyclicDataFlowException(Exception):
         super(CyclicDataFlowException, self).__init__(
             "DataFlow {} has cycles.".format(dataflow_id)
         )
+
+
+class ParametersException(ValueError):
+    def __init__(self, msg):
+        super(ParametersException, self).__init__(msg)

--- a/simple_repo/simple_pandas/__init__.py
+++ b/simple_repo/simple_pandas/__init__.py
@@ -1,5 +1,5 @@
 from simple_repo.simple_pandas.transform_nodes import (
-    PandasColumnSelector,
+    PandasColumnsFiltering,
     PandasPivot,
     PandasRenameColumn,
 )

--- a/simple_repo/simple_pandas/transform_nodes.py
+++ b/simple_repo/simple_pandas/transform_nodes.py
@@ -1,90 +1,136 @@
+from typing import List, Tuple
+
 import pandas
 
-from simple_repo.parameter import KeyValueParameter, StructuredParameterList, Parameters
+from simple_repo.exception import ParametersException
+from simple_repo.parameter import KeyValueParameter, Parameters
 from simple_repo.simple_pandas.node_structure import PandasNode
 
 
-def _filter_column_by_value(dataset, column: str, value):
-    """
-    Utility function used, given a dataset, to filter a specific column with a specific value
-    """
-    dataset = dataset[dataset[column] == value]
-    return dataset
+# def _filter_column_by_value(dataset, column: str, value):
+#     """
+#     Utility function used, given a dataset, to filter a specific column with a specific value
+#     """
+#     dataset = dataset[dataset[column] == value]
+#     return dataset
+#
+#
+# def _set_column_type(dataset, column: str, column_type: str):
+#     """
+#     Utility function used, given a dataset, to set the type of a specific column
+#     """
+#     if column_type == "string":
+#         dataset[column] = dataset[column].astype(column_type)
+#     elif column_type == "timedelta":
+#         dataset[column] = pandas.to_timedelta(dataset[column])
+#         dataset[column] = dataset[column].apply(lambda elem: elem.total_seconds())
+#     elif column_type == "datetime":
+#         dataset[column] = pandas.to_datetime(dataset[column]).dt.date
+#     return dataset
+#
+#
+# def _filter_feature(dataset, feature):
+#     """
+#     Utility function used to manipulate a dataset and apply the given feature
+#     """
+#     try:
+#         dataset = _set_column_type(dataset, feature["name"], feature["type"])
+#     except Exception:
+#         pass
+#     try:
+#         dataset = _filter_column_by_value(
+#             dataset, feature["name"], feature["filter_value"]
+#         )
+#     except Exception:
+#         pass
+#     return dataset
+#
+#
+# def _filter(self):
+#     """
+#     Method used to apply the feature preprocessing to the given dataset.
+#     """
+#     features = self.parameters.columns.parameters
+#     if "*" in [x["name"] for x in features]:
+#         for feature in features:
+#             self.dataset = _filter_feature(self.dataset, feature)
+#     else:
+#         features_list = []
+#         for feature in features:
+#             self.dataset = _filter_feature(self.dataset, feature)
+#             features_list.append(feature["name"])
+#         self.dataset = self.dataset.filter(features_list)
+#     return self.dataset
 
 
-def _set_column_type(dataset, column: str, column_type: str):
-    """
-    Utility function used, given a dataset, to set the type of a specific column
-    """
-    if column_type == "string":
-        dataset[column] = dataset[column].astype(column_type)
-    elif column_type == "timedelta":
-        dataset[column] = pandas.to_timedelta(dataset[column])
-        dataset[column] = dataset[column].apply(lambda elem: elem.total_seconds())
-    elif column_type == "datetime":
-        dataset[column] = pandas.to_datetime(dataset[column]).dt.date
-    return dataset
-
-
-def _filter_feature(dataset, feature):
-    """
-    Utility function used to manipulate a dataset and apply the given feature
-    """
-    try:
-        dataset = _set_column_type(dataset, feature["name"], feature["type"])
-    except Exception:
-        pass
-    try:
-        dataset = _filter_column_by_value(
-            dataset, feature["name"], feature["filter_value"]
-        )
-    except Exception:
-        pass
-    return dataset
-
-
-class PandasColumnSelector(PandasNode):
-    """PandasColumnSelector manages filtering of rows, columns and values.
+class PandasColumnsFiltering(PandasNode):
+    """PandasColumnsFiltering manages filtering of columns.
 
     Parameters
     ----------
-    columns : list[dict]
-        Every dictionary in the list must be of the form:
-            {
-                name: str (Mandatory)
-                type: str (Optional)
-            }
+    node_id : str
+        Id of the node.
+    column_indexes : List[int]
+        Filters the dataset selecting the given indexes. Uses the pandas iloc function.
+    column_names : List[str]
+        Filters the dataset selecting the given column labels. Uses the pandas filter function.
+    columns_like : str
+        Keep columns for which the given string is a substring of the column label.
+    columns_regex : str
+        Keep columns for which column labels match a given pattern.
+    columns_range : Tuple[int, int]
+        Keep columns for which index falls withing the given range (from, to (included)).
     """
 
-    def __init__(self, node_id: str, columns: list):
-        super(PandasColumnSelector, self).__init__(node_id)
-        self.parameters = Parameters(
-            # A variable number of columns can be passed, but all of them must have the same structure specified here.
-            # A keyword represent the keyword that can be written in the json, the value True or False tells if it is
-            # mandatory or not.
-            columns=StructuredParameterList(name=True, type=False)
+    def __init__(
+        self,
+        node_id: str,
+        column_indexes: List[int] = None,
+        column_names: List[str] = None,
+        columns_like: str = None,
+        columns_regex: str = None,
+        columns_range: Tuple[int, int] = None,
+    ):
+        super(PandasColumnsFiltering, self).__init__(node_id)
+
+        none_parameters = sum(
+            parameter is not None
+            for parameter in [
+                column_indexes,
+                column_names,
+                columns_like,
+                columns_regex,
+                columns_range,
+            ]
         )
 
-        self.parameters.columns.add_all_parameters(*columns)
+        if none_parameters > 1:
+            raise ParametersException("Filtering parameters are mutually exclusive.")
 
-    def _filter(self):
-        """
-        Method used to apply the feature preprocessing to the given dataset.
-        """
-        features = self.parameters.columns.parameters
-        if "*" in [x["name"] for x in features]:
-            for feature in features:
-                self.dataset = _filter_feature(self.dataset, feature)
-        else:
-            features_list = []
-            for feature in features:
-                self.dataset = _filter_feature(self.dataset, feature)
-                features_list.append(feature["name"])
-            self.dataset = self.dataset.filter(features_list)
-        return self.dataset
+        self.parameters = Parameters(
+            columns_range=KeyValueParameter("range", str, value=columns_range),
+            column_indexes=KeyValueParameter("indexes", str, value=column_indexes),
+            column_names=KeyValueParameter("items", str, value=column_names),
+            columns_like=KeyValueParameter("like", str, value=columns_like),
+            axis=KeyValueParameter("axis", str, value="columns"),
+            columns_regex=KeyValueParameter("regex", str, value=columns_regex),
+        )
+
+        self.parameters.add_group(
+            "filter", keys=["column_names", "columns_like", "columns_regex", "axis"]
+        )
 
     def execute(self):
-        self.dataset = self._filter()
+        if self.parameters.column_indexes.value:
+            self.dataset = self.dataset.iloc[:, self.parameters.column_indexes.value]
+        elif self.parameters.columns_range.value:
+            from_var = self.parameters.columns_range.value[0]
+            to_var = self.parameters.columns_range.value[1]
+            self.dataset = self.dataset.iloc[:, from_var:to_var]
+        else:
+            self.dataset = self.dataset.filter(
+                **self.parameters.get_dict_from_group("filter")
+            )
 
 
 class PandasPivot(PandasNode):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -34,7 +34,7 @@ def test_output_node_attributes(class_or_obj):
 
 
 computational_data = [
-    sr.PandasColumnSelector,
+    sr.PandasColumnsFiltering,
     sr.PandasPivot,
     sr.PandasRenameColumn,
     sr.SimpleKMeans,

--- a/tests/test_commons.py
+++ b/tests/test_commons.py
@@ -1,7 +1,7 @@
 import pytest
 
 from simple_repo import (
-    PandasColumnSelector,
+    PandasColumnsFiltering,
     PandasPivot,
     PandasRenameColumn,
     SklearnLinearSVC,
@@ -76,7 +76,7 @@ classes = [
     (PandasOutputNode, ["dataset"], None, None),
     (PandasCSVWriter, ["dataset"], None, None),
     (PandasNode, ["dataset"], ["dataset"], None),
-    (PandasColumnSelector, ["dataset"], ["dataset"], None),
+    (PandasColumnsFiltering, ["dataset"], ["dataset"], None),
     (PandasPivot, ["dataset"], ["dataset"], None),
     (PandasRenameColumn, ["dataset"], ["dataset"], None),  # Spark Nodes
     (SparkInputNode, None, [], None),

--- a/tests/test_pandas/test_pandas_nodes.py
+++ b/tests/test_pandas/test_pandas_nodes.py
@@ -5,7 +5,7 @@ import simple_repo.simple_pandas as sp
 import simple_repo.simple_io.pandas_io as pio
 
 pandas_nodes = [
-    sp.PandasColumnSelector,
+    sp.PandasColumnsFiltering,
     sp.PandasPivot,
     sp.PandasRenameColumn,
     pio.PandasCSVLoader,

--- a/tests/test_pandas/test_pandas_transform.py
+++ b/tests/test_pandas/test_pandas_transform.py
@@ -1,13 +1,12 @@
+import pandas as pd
+import numpy as np
 import pytest
 from sklearn.datasets import load_iris
 
 from simple_repo import (
-    PandasColumnSelector,
-    PandasPivot,
-    PandasRenameColumn,
+    PandasColumnsFiltering,
 )
-from simple_repo.exception import ParameterNotFound
-from tests.test_commons import check_param_not_found
+from simple_repo.exception import ParametersException
 
 
 @pytest.fixture
@@ -15,27 +14,95 @@ def iris_data():
     yield load_iris(as_frame=True).data
 
 
-class TestPandasColumnSelector:
+incorrect_parameters = [
+    {"column_indexes": [1, 2], "column_names": ["one", "two"]},
+    {"column_indexes": [1, 2], "columns_like": "one"},
+    {"column_names": ["one", "two"], "columns_regex": "e$"},
+    {"columns_range": (0, 3), "columns_regex": "e$"},
+]
+
+
+class TestPandasColumnsFiltering:
+    @pytest.mark.parametrize("params", incorrect_parameters)
+    def test_parameter_exception(self, params):
+        with pytest.raises(ParametersException):
+            PandasColumnsFiltering("prf", **params)
+
     @pytest.fixture
-    def selector_data(self):
-        correct_cols = [{"name": "sepal length (cm)", "type": "float"}]
-        selector = PandasColumnSelector("pcs1", columns=correct_cols)
-        yield selector
+    def initial_dataframe(self):
+        yield pd.DataFrame(
+            np.array(([1, 2, 3], [4, 5, 6])),
+            index=["mouse", "rabbit"],
+            columns=["one", "two", "three"],
+        )
 
-    def test_parameter_not_found_exception(self):
-        """Tests whether the class raises a ParameterNotFound exception."""
-        incorrect_cols = [{"nome": "c1", "type": "tipo"}]
-        with pytest.raises(ParameterNotFound):
-            check_param_not_found(PandasColumnSelector, columns=incorrect_cols)
+    def test_column_index_filtering(self, initial_dataframe):
+        prf = PandasColumnsFiltering("prf", column_indexes=[0])
+        prf.set_input_value("dataset", initial_dataframe)
 
-    def test_column_selection(self, iris_data, selector_data):
-        sel = selector_data
-        sel.dataset = iris_data
-        print(sel.dataset)
-        sel.execute()
-        print(sel.dataset, sel.dataset.shape, sel.dataset.iloc[:, 0].dtype)
-        assert sel.dataset.shape == (iris_data.shape[0], 1)
-        assert sel.dataset.iloc[:, 0].dtype == float
+        prf.execute()
+
+        expected_df = pd.DataFrame(
+            np.array(([1], [4])), index=["mouse", "rabbit"], columns=["one"]
+        )
+
+        assert prf.dataset.equals(expected_df)
+
+    def test_column_index_range_filtering(self, initial_dataframe):
+        prf = PandasColumnsFiltering("prf", columns_range=(0, 2))
+        prf.set_input_value("dataset", initial_dataframe)
+
+        prf.execute()
+
+        expected_df = pd.DataFrame(
+            np.array(([1, 2], [4, 5])),
+            index=["mouse", "rabbit"],
+            columns=["one", "two"],
+        )
+
+        assert prf.dataset.equals(expected_df)
+
+    def test_column_names_filtering(self, initial_dataframe):
+        prf = PandasColumnsFiltering("prf", column_names=["one", "three"])
+        prf.set_input_value("dataset", initial_dataframe)
+
+        prf.execute()
+
+        expected_df = pd.DataFrame(
+            np.array(([1, 3], [4, 6])),
+            index=["mouse", "rabbit"],
+            columns=["one", "three"],
+        )
+
+        assert prf.dataset.equals(expected_df)
+
+    def test_column_regex_filtering(self, initial_dataframe):
+        prf = PandasColumnsFiltering("prf", columns_regex="e$")
+        prf.set_input_value("dataset", initial_dataframe)
+
+        prf.execute()
+
+        expected_df = pd.DataFrame(
+            np.array(([1, 3], [4, 6])),
+            index=["mouse", "rabbit"],
+            columns=["one", "three"],
+        )
+
+        assert prf.dataset.equals(expected_df)
+
+    def test_column_like_filtering(self, initial_dataframe):
+        prf = PandasColumnsFiltering("prf", columns_like="o")
+        prf.set_input_value("dataset", initial_dataframe)
+
+        prf.execute()
+
+        expected_df = pd.DataFrame(
+            np.array(([1, 2], [4, 5])),
+            index=["mouse", "rabbit"],
+            columns=["one", "two"],
+        )
+
+        assert prf.dataset.equals(expected_df)
 
 
 class TestPandasPivot:


### PR DESCRIPTION
PandasColumnSelector ora utilizza una StructuredParameterList per gestire i parametri delle colonne da filtrare, generando qualche problema nell'utilizzo di tale struttura. Risulta particolarmente difficile capire bene come si utilizza tale struttura, quindi sarebbe meglio cambiare approccio nella gestione di tale oggetto utilizzando dei normali parametri all'init.

PandasColumnSelector è stato rinominato in PandasColumnsFiltering e ora gestisce esclusivamente il filtering delle colonne e non più anche di righe e valori. La gestione di tali filtri potrà successivamente essere integrata ad esso o spostata in oggetti separati. Occupandosi solamente delle colonne sono state aggiunte delle funzionalità aggiuntive ed ora non viene più utilizzata la StructuredParameterList ma semplicemente dei kwargs all'init. Le funzionalità attualmente implementate dal nodo sono mutualmente esclusive, il che significa che ogni parametro assolve ad una specifica funzionalità e non può essere utilizzato in congiunzione con gli altri.